### PR TITLE
NewHTTP: No allocations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.ajitem.com/zapdriver
 go 1.17
 
 require (
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.1
 )

--- a/http.go
+++ b/http.go
@@ -11,7 +11,6 @@ package zapdriver
 // pipe-1&dateRangeUnbound=backwardInTime
 
 import (
-	"bytes"
 	"io"
 	"net/http"
 	"strconv"
@@ -134,9 +133,8 @@ func NewHTTP(req *http.Request, res *http.Response) *HTTPPayload {
 		}
 	}
 
-	buf := &bytes.Buffer{}
 	if req.Body != nil {
-		n, _ := io.Copy(buf, req.Body) // nolint: gas
+		n, _ := io.Copy(io.Discard, req.Body) // nolint: gas
 		requestSize += n
 	}
 
@@ -153,8 +151,7 @@ func NewHTTP(req *http.Request, res *http.Response) *HTTPPayload {
 	}
 
 	if res.Body != nil {
-		buf.Reset()
-		n, _ := io.Copy(buf, res.Body) // nolint: gas
+		n, _ := io.Copy(io.Discard, res.Body) // nolint: gas
 		responseSize += n
 	}
 
@@ -164,7 +161,7 @@ func NewHTTP(req *http.Request, res *http.Response) *HTTPPayload {
 }
 
 // MarshalLogObject implements zapcore.ObjectMarshaller interface.
-func (req HTTPPayload) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+func (req *HTTPPayload) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("requestMethod", req.RequestMethod)
 	enc.AddString("requestUrl", req.RequestURL)
 	enc.AddInt("status", req.Status)

--- a/http.go
+++ b/http.go
@@ -22,7 +22,7 @@ import (
 // HTTP adds the correct Stackdriver "HTTP" field.
 //
 // see: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
-func HTTP(req *HTTPPayload) zap.Field {
+func HTTP(req HTTPPayload) zap.Field {
 	return zap.Object("httpRequest", req)
 }
 
@@ -100,7 +100,7 @@ type HTTPPayload struct {
 
 // NewHTTP returns a new HTTPPayload struct, based on the passed
 // in http.Request and http.Response objects.
-func NewHTTP(req *http.Request, res *http.Response) *HTTPPayload {
+func NewHTTP(req *http.Request, res *http.Response) HTTPPayload {
 	if req == nil {
 		req = &http.Request{}
 	}
@@ -109,7 +109,7 @@ func NewHTTP(req *http.Request, res *http.Response) *HTTPPayload {
 		res = &http.Response{}
 	}
 
-	sdreq := &HTTPPayload{
+	sdreq := HTTPPayload{
 		RequestMethod: req.Method,
 		Status:        res.StatusCode,
 		UserAgent:     req.UserAgent(),
@@ -161,7 +161,7 @@ func NewHTTP(req *http.Request, res *http.Response) *HTTPPayload {
 }
 
 // MarshalLogObject implements zapcore.ObjectMarshaller interface.
-func (req *HTTPPayload) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+func (req HTTPPayload) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("requestMethod", req.RequestMethod)
 	enc.AddString("requestUrl", req.RequestURL)
 	enc.AddInt("status", req.Status)

--- a/http_test.go
+++ b/http_test.go
@@ -14,10 +14,20 @@ import (
 	"go.ajitem.com/zapdriver"
 )
 
+func BenchmarkHTTP(b *testing.B) {
+	b.ReportAllocs()
+	b.RunParallel(func(b *testing.PB) {
+		for b.Next() {
+			p := zapdriver.NewHTTP(nil, nil)
+			_ = zapdriver.HTTP(p)
+		}
+	})
+}
+
 func TestHTTP(t *testing.T) {
 	t.Parallel()
 
-	req := &zapdriver.HTTPPayload{}
+	var req zapdriver.HTTPPayload
 	field := zapdriver.HTTP(req)
 
 	assert.Equal(t, zap.Object("httpRequest", req), field)

--- a/http_test.go
+++ b/http_test.go
@@ -1,7 +1,7 @@
 package zapdriver_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"go.uber.org/zap"
 
 	"go.ajitem.com/zapdriver"
@@ -81,14 +80,14 @@ func TestNewHTTP(t *testing.T) {
 		},
 
 		"RequestSize": {
-			&http.Request{Body: ioutil.NopCloser(strings.NewReader("12345"))},
+			&http.Request{Body: io.NopCloser(strings.NewReader("12345"))},
 			nil,
 			&zapdriver.HTTPPayload{RequestSize: "5", ResponseSize: "0"},
 		},
 
 		"ResponseSize": {
 			nil,
-			&http.Response{Body: ioutil.NopCloser(strings.NewReader("12345"))},
+			&http.Response{Body: io.NopCloser(strings.NewReader("12345"))},
 			&zapdriver.HTTPPayload{ResponseSize: "5", RequestSize: "0"},
 		},
 
@@ -108,7 +107,7 @@ func TestNewHTTP(t *testing.T) {
 
 		"simple response": {
 			nil,
-			&http.Response{Body: ioutil.NopCloser(strings.NewReader("12345")), StatusCode: 404},
+			&http.Response{Body: io.NopCloser(strings.NewReader("12345")), StatusCode: 404},
 			&zapdriver.HTTPPayload{RequestSize: "0", ResponseSize: "5", Status: 404},
 		},
 

--- a/report.go
+++ b/report.go
@@ -43,7 +43,7 @@ type reportContext struct {
 
 // MarshalLogObject implements zapcore.ObjectMarshaller interface.
 func (context reportContext) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	enc.AddObject("reportLocation", context.ReportLocation)
+	_ = enc.AddObject("reportLocation", context.ReportLocation)
 
 	return nil
 }


### PR DESCRIPTION
I noticed `NewHTTP()` is allocating 240B/call. These allocations are:

1. Creating a new `*bytes.Buffer` (48B). We used this to get the request/response body size (never read the values) and it's eligible for GC at the end of the function.
2. Returning a `*HTTPPayload` (192B)

Falling in the spirit of Zap (zero allocations per op), this PR removes allocations for HTTP:

* Use `io.Discard` instead of allocating a buffer.
* Return `HTTPPayload` instead of `*HTTPPayload`.
* Accept `HTTPPayload` in `HTTP()`.

This 

```
Running tool: /usr/local/bin/go test -benchmem -run=^$ -coverprofile=/var/folders/sq/bxg3__pn49l78dyg9vgwl9c80000gn/T/vscode-goatP83c/go-code-cover -covermode atomic -bench ^(BenchmarkNewHTTP|BenchmarkNewHTTP_NoBodyAlloc|BenchmarkNewHTTP_NoAllocs)$ go.ajitem.com/zapdriver -race -v

goos: darwin
goarch: amd64
pkg: go.ajitem.com/zapdriver
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkNewHTTP
BenchmarkNewHTTP-12			  914928	      1200 ns/op	     240 B/op	       2 allocs/op
BenchmarkNewHTTP_NoAlloc
BenchmarkNewHTTP_NoAlloc-12          	 1000000	      1102 ns/op	       0 B/op	       0 allocs/op
PASS
coverage: 14.7% of statements
ok  	go.ajitem.com/zapdriver	4.709s
```

```go
func BenchmarkNewHTTP(b *testing.B) {
	b.ReportAllocs()
	b.RunParallel(func(b *testing.PB) {
		for b.Next() {
			p := NewHTTP(nil, nil)
			_ = HTTP(p)
		}
	}
}
```

I also made two unrelated (linter) changes:

* Ran `go mod tidy`
* Replaced `ioutil` with `io`
* Made an ignored error explicit.