### PR TITLE
fix: Fix TestNewHTTP

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -39,72 +39,72 @@ func TestNewHTTP(t *testing.T) {
 	var tests = map[string]struct {
 		req  *http.Request
 		res  *http.Response
-		want *zapdriver.HTTPPayload
+		want zapdriver.HTTPPayload
 	}{
 		"empty": {
 			nil,
 			nil,
-			&zapdriver.HTTPPayload{RequestSize: "0", ResponseSize: "0"},
+			zapdriver.HTTPPayload{RequestSize: "0", ResponseSize: "0"},
 		},
 
 		"RequestMethod": {
 			&http.Request{Method: "GET"},
 			nil,
-			&zapdriver.HTTPPayload{RequestMethod: "GET", RequestSize: "0", ResponseSize: "0"},
+			zapdriver.HTTPPayload{RequestMethod: "GET", RequestSize: "0", ResponseSize: "0"},
 		},
 
 		"Status": {
 			nil,
 			&http.Response{StatusCode: 404},
-			&zapdriver.HTTPPayload{Status: 404, RequestSize: "0", ResponseSize: "0"},
+			zapdriver.HTTPPayload{Status: 404, RequestSize: "0", ResponseSize: "0"},
 		},
 
 		"UserAgent": {
 			&http.Request{Header: http.Header{"User-Agent": []string{"hello world"}}},
 			nil,
-			&zapdriver.HTTPPayload{UserAgent: "hello world", RequestSize: "21", ResponseSize: "0"},
+			zapdriver.HTTPPayload{UserAgent: "hello world", RequestSize: "21", ResponseSize: "0"},
 		},
 
 		"RemoteIP": {
 			&http.Request{RemoteAddr: "127.0.0.1"},
 			nil,
-			&zapdriver.HTTPPayload{RemoteIP: "127.0.0.1", RequestSize: "0", ResponseSize: "0"},
+			zapdriver.HTTPPayload{RemoteIP: "127.0.0.1", RequestSize: "0", ResponseSize: "0"},
 		},
 
 		"Referrer": {
 			&http.Request{Header: http.Header{"Referer": []string{"hello universe"}}},
 			nil,
-			&zapdriver.HTTPPayload{Referer: "hello universe", RequestSize: "21", ResponseSize: "0"},
+			zapdriver.HTTPPayload{Referer: "hello universe", RequestSize: "21", ResponseSize: "0"},
 		},
 
 		"Protocol": {
 			&http.Request{Proto: "HTTP/1.1"},
 			nil,
-			&zapdriver.HTTPPayload{Protocol: "HTTP/1.1", RequestSize: "0", ResponseSize: "0"},
+			zapdriver.HTTPPayload{Protocol: "HTTP/1.1", RequestSize: "0", ResponseSize: "0"},
 		},
 
 		"RequestURL": {
 			&http.Request{URL: &url.URL{Host: "example.com", Scheme: "https"}},
 			nil,
-			&zapdriver.HTTPPayload{RequestURL: "https://example.com", RequestSize: "0", ResponseSize: "0"},
+			zapdriver.HTTPPayload{RequestURL: "https://example.com", RequestSize: "0", ResponseSize: "0"},
 		},
 
 		"RequestSize": {
 			&http.Request{Body: io.NopCloser(strings.NewReader("12345"))},
 			nil,
-			&zapdriver.HTTPPayload{RequestSize: "5", ResponseSize: "0"},
+			zapdriver.HTTPPayload{RequestSize: "5", ResponseSize: "0"},
 		},
 
 		"ResponseSize": {
 			nil,
 			&http.Response{Body: io.NopCloser(strings.NewReader("12345"))},
-			&zapdriver.HTTPPayload{ResponseSize: "5", RequestSize: "0"},
+			zapdriver.HTTPPayload{ResponseSize: "5", RequestSize: "0"},
 		},
 
 		"simple request": {
 			httptest.NewRequest("POST", "/", strings.NewReader("12345")),
 			nil,
-			&zapdriver.HTTPPayload{
+			zapdriver.HTTPPayload{
 				RequestSize:   "5",
 				RequestMethod: "POST",
 				RemoteIP:      "192.0.2.1:1234",
@@ -118,13 +118,13 @@ func TestNewHTTP(t *testing.T) {
 		"simple response": {
 			nil,
 			&http.Response{Body: io.NopCloser(strings.NewReader("12345")), StatusCode: 404},
-			&zapdriver.HTTPPayload{RequestSize: "0", ResponseSize: "5", Status: 404},
+			zapdriver.HTTPPayload{RequestSize: "0", ResponseSize: "5", Status: 404},
 		},
 
 		"request & response": {
 			&http.Request{Method: "POST", Proto: "HTTP/1.1"},
 			&http.Response{StatusCode: 200},
-			&zapdriver.HTTPPayload{RequestMethod: "POST", Protocol: "HTTP/1.1", Status: 200, RequestSize: "0", ResponseSize: "0"},
+			zapdriver.HTTPPayload{RequestMethod: "POST", Protocol: "HTTP/1.1", Status: 200, RequestSize: "0", ResponseSize: "0"},
 		},
 	}
 


### PR DESCRIPTION
Hi,

I ran `go test ./...` and some tests failed due to a type mismatch between the expected and actual values of `HTTPPayload`.

I fixed the issue by this PR.  Please take a look when you have a moment.

Here’s a sample of the failure:

```sh
    --- FAIL: TestNewHTTP/simple_request (0.00s)
        http_test.go:133:
                Error Trace:    /Users/shiwano/code/src/github.com/shiwano/zapdriver/http_test.go:133
                Error:          Not equal:
                                expected: *zapdriver.HTTPPayload(&zapdriver.HTTPPayload{RequestMethod:"POST", RequestURL:"/", RequestSize:"5", Status:0, ResponseSize:"0", UserAgent:"", RemoteIP:"192.0.2.1:1234", ServerIP:"example.com", Referer:"", Latency:"", CacheLookup:false, CacheHit:false, CacheValidatedWithOriginServer:false, CacheFillBytes:"", Protocol:"HTTP/1.1"})
                                actual  : zapdriver.HTTPPayload(zapdriver.HTTPPayload{RequestMethod:"POST", RequestURL:"/", RequestSize:"5", Status:0, ResponseSize:"0", UserAgent:"", RemoteIP:"192.0.2.1:1234", ServerIP:"example.com", Referer:"", Latency:"", CacheLookup:false, CacheHit:false, CacheValidatedWithOriginServer:false, CacheFillBytes:"", Protocol:"HTTP/1.1"})
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,2 +1,2 @@
                                -(*zapdriver.HTTPPayload)({
                                +(zapdriver.HTTPPayload) {
                                  RequestMethod: (string) (len=4) "POST",
                                @@ -16,3 +16,3 @@
                                  Protocol: (string) (len=8) "HTTP/1.1"
                                -})
                                +}
```