### PR TITLE
fix: Fix reportLocation format

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -2,7 +2,6 @@ package zapdriver
 
 import (
 	"runtime"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -335,7 +334,7 @@ func TestWriteReportAllErrors(t *testing.T) {
 	context := logs.All()[0].ContextMap()[contextKey].(map[string]interface{})
 	rLocation := context["reportLocation"].(map[string]interface{})
 	assert.Contains(t, rLocation["filePath"], "zapdriver/core_test.go")
-	assert.Equal(t, strconv.Itoa(line), rLocation["lineNumber"])
+	assert.Equal(t, line, rLocation["lineNumber"])
 	assert.Contains(t, rLocation["functionName"], "zapdriver.TestWriteReportAllErrors")
 
 	// Assert that a service context was attached even though service name was not set

--- a/report.go
+++ b/report.go
@@ -2,7 +2,6 @@ package zapdriver
 
 import (
 	"runtime"
-	"strconv"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -23,14 +22,14 @@ func ErrorReport(pc uintptr, file string, line int, ok bool) zap.Field {
 // if any.
 type reportLocation struct {
 	File     string `json:"filePath"`
-	Line     string `json:"lineNumber"`
+	Line     int    `json:"lineNumber"`
 	Function string `json:"functionName"`
 }
 
 // MarshalLogObject implements zapcore.ObjectMarshaller interface.
 func (location reportLocation) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("filePath", location.File)
-	enc.AddString("lineNumber", location.Line)
+	enc.AddInt("lineNumber", location.Line)
 	enc.AddString("functionName", location.Function)
 
 	return nil
@@ -61,7 +60,7 @@ func newReportContext(pc uintptr, file string, line int, ok bool) *reportContext
 	context := &reportContext{
 		ReportLocation: reportLocation{
 			File:     file,
-			Line:     strconv.Itoa(line),
+			Line:     line,
 			Function: function,
 		},
 	}

--- a/report_test.go
+++ b/report_test.go
@@ -13,7 +13,7 @@ func TestErrorReport(t *testing.T) {
 	got := ErrorReport(runtime.Caller(0)).Interface.(*reportContext)
 
 	assert.Contains(t, got.ReportLocation.File, "zapdriver/report_test.go")
-	assert.Equal(t, "13", got.ReportLocation.Line)
+	assert.Equal(t, 13, got.ReportLocation.Line)
 	assert.Contains(t, got.ReportLocation.Function, "zapdriver.TestErrorReport")
 }
 
@@ -23,6 +23,6 @@ func TestNewReportContext(t *testing.T) {
 	got := newReportContext(runtime.Caller(0))
 
 	assert.Contains(t, got.ReportLocation.File, "zapdriver/report_test.go")
-	assert.Equal(t, "23", got.ReportLocation.Line)
+	assert.Equal(t, 23, got.ReportLocation.Line)
 	assert.Contains(t, got.ReportLocation.Function, "zapdriver.TestNewReportContext")
 }


### PR DESCRIPTION
Hi,

https://cloud.google.com/error-reporting/reference/rest/v1beta1/ErrorContext#SourceLocation
> lineNumber
> integer 1-based. 0 indicates that the line number is unknown.

The `lineNumber` field in `context.reportLocation` should be an `int`, not a `string`.
Google Cloud Observability ignores `lineNumber` when it is a `string`, so I fixed it.

Please take a look when you have a moment.